### PR TITLE
Add wildcard site alias environments.

### DIFF
--- a/src/Cli/SiteAliasCommands.php
+++ b/src/Cli/SiteAliasCommands.php
@@ -3,6 +3,7 @@
 namespace Consolidation\SiteAlias\Cli;
 
 use Consolidation\SiteAlias\SiteAliasFileLoader;
+use Consolidation\SiteAlias\SiteAliasManager;
 use Consolidation\SiteAlias\Util\YamlDataFileLoader;
 use Consolidation\SiteAlias\SiteSpecParser;
 
@@ -40,6 +41,33 @@ class SiteAliasCommands extends \Robo\Tasks
         }
 
         return $result;
+    }
+
+    /**
+     * List available site aliases.
+     *
+     * @command site:get
+     * @format yaml
+     * @return array
+     */
+    public function siteGet($alias, array $dirs)
+    {
+        $this->aliasLoader = new SiteAliasFileLoader();
+        $ymlLoader = new YamlDataFileLoader();
+        $this->aliasLoader->addLoader('yml', $ymlLoader);
+
+        foreach ($dirs as $dir) {
+            $this->io()->note("Add search location: $dir");
+            $this->aliasLoader->addSearchLocation($dir);
+        }
+
+        $manager = new SiteAliasManager($this->aliasLoader);
+        $result = $manager->get($alias);
+        if (!$result) {
+            throw new \Exception("No alias found");
+        }
+
+        return $result->export();
     }
 
     /**

--- a/tests/SiteAliasFileLoaderTest.php
+++ b/tests/SiteAliasFileLoaderTest.php
@@ -17,6 +17,31 @@ class SiteAliasFileLoaderTest extends TestCase
         $this->sut->addLoader('yml', $ymlLoader);
     }
 
+    public function testLoadWildAliasFile()
+    {
+        $siteAliasFixtures = $this->fixturesDir() . '/sitealiases/sites';
+        $this->assertTrue(is_dir($siteAliasFixtures));
+        $this->assertTrue(is_file($siteAliasFixtures . '/wild.site.yml'));
+
+        $this->sut->addSearchLocation($siteAliasFixtures);
+
+        // Try to get the dev environment.
+        $name = SiteAliasName::parse('@wild.dev');
+        $result = $this->callProtected('loadSingleAliasFile', [$name]);
+        $this->assertTrue($result instanceof AliasRecord);
+        $this->assertEquals('/path/to/wild', $result->get('root'));
+        $this->assertEquals('bar', $result->get('foo'));
+
+        // Try to fetch an environment that does not exist. Since this is
+        // a wildcard alias, there should
+        $name = SiteAliasName::parse('@wild.other');
+        $result = $this->callProtected('loadSingleAliasFile', [$name]);
+        $this->assertTrue($result instanceof AliasRecord);
+        $this->assertEquals('/wild/path/to/wild', $result->get('root'));
+        $this->assertEquals('bar', $result->get('foo'));
+
+    }
+
     public function testLoadSingleAliasFile()
     {
         $siteAliasFixtures = $this->fixturesDir() . '/sitealiases/sites';
@@ -117,7 +142,7 @@ class SiteAliasFileLoaderTest extends TestCase
         $this->sut->addSearchLocation($this->fixturesDir() . '/sitealiases/other');
 
         $all = $this->sut->loadAll();
-        $this->assertEquals('@other.single.common,@other.single.dev,@other.single.other,@single.alternate,@single.common,@single.dev', implode(',', array_keys($all)));
+        $this->assertEquals('@other.single.common,@other.single.dev,@other.single.other,@single.alternate,@single.common,@single.dev,@wild.*,@wild.common,@wild.dev', implode(',', array_keys($all)));
     }
 
     public function testLoadMultiple()

--- a/tests/fixtures/sitealiases/sites/wild.site.yml
+++ b/tests/fixtures/sitealiases/sites/wild.site.yml
@@ -1,0 +1,9 @@
+default: dev
+dev:
+  root: /path/to/wild
+  uri: https://dev.example.com
+'*':
+  root: /wild/path/to/wild
+  uri: https://${env-name}.example.com
+common:
+  foo: bar


### PR DESCRIPTION


### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Has tests?    | no
| BC breaks?    | no     
| Deprecations? | no 

### Summary
If a site alias contains an environment named '*', then this wildcard environment will match for any requested environment name that does not specifically match some other environment in the alias record. The variable ${env-name} will be replaced with the requested environment name. This allows to aliases to be defined in situations where different environments are identical save for field data that varies only by environment name. An example of this is aliases for Pantheon multidev environment.
