### PR TITLE
Added base name of file as accepted file pattern

### DIFF
--- a/src/SiteAliasFileDiscovery.php
+++ b/src/SiteAliasFileDiscovery.php
@@ -136,7 +136,8 @@ class SiteAliasFileDiscovery
     {
         return array_merge(
             $this->searchForAliasFiles('*.alias.drushrc.php'),
-            $this->searchForAliasFiles('*.aliases.drushrc.php')
+            $this->searchForAliasFiles('*.aliases.drushrc.php'),
+            $this->searchForAliasFiles('aliases.drushrc.php')
         );
     }
 

--- a/tests/SiteAliasFileDiscoveryTest.php
+++ b/tests/SiteAliasFileDiscoveryTest.php
@@ -36,7 +36,7 @@ class SiteAliasFileDiscoveryTest extends TestCase
 
         $result = $this->sut->findAllLegacyAliasFiles();
         $paths = $this->simplifyToBasenamesWithLocation($result);
-        $this->assertEquals('legacy/cc.aliases.drushrc.php,legacy/one.alias.drushrc.php,legacy/pantheon.aliases.drushrc.php,legacy/server.aliases.drushrc.php', implode(',', $paths));
+        $this->assertEquals('legacy/aliases.drushrc.php,legacy/cc.aliases.drushrc.php,legacy/one.alias.drushrc.php,legacy/pantheon.aliases.drushrc.php,legacy/server.aliases.drushrc.php', implode(',', $paths));
     }
 
     protected function assertLocation($expected, $path)

--- a/tests/fixtures/sitealiases/legacy/aliases.drushrc.php
+++ b/tests/fixtures/sitealiases/legacy/aliases.drushrc.php
@@ -1,0 +1,11 @@
+<?php
+
+$aliases['production'] = [
+    'uri' => 'example.com',
+    'root' => '/path/to/drupal',
+];
+
+$aliases['staging'] = [
+    'uri' => 'staging.example.com',
+    'root' => '/path/to/drupal',
+];

--- a/tests/fixtures/sitealiases/legacy/do-not-find-me.php
+++ b/tests/fixtures/sitealiases/legacy/do-not-find-me.php
@@ -1,0 +1,3 @@
+<?php
+
+// The search scripts shouldn't find me as I do not match the patterns.


### PR DESCRIPTION
### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Has tests?    | yes
| BC breaks?    | no     
| Deprecations? | no 

### Summary
In previous versions of Drush it was possible to place a project specific aliases.drushrc.php file in the drush folder of your composer project. The best example I can find of this is in https://github.com/amazeeio/drupal-example where we have at the composer root level a drush folder with the file mentioned in it.

### Description
Added the files to the lookups and adjusted the test for it, additionally added a file to the list that shouldn't show up, which is implicit tested for in the test case – based on the fact that it is not in the list files in the assertion.
