### PR TITLE
Fix get multiple

### DIFF
--- a/src/SiteAliasFileDiscovery.php
+++ b/src/SiteAliasFileDiscovery.php
@@ -175,11 +175,14 @@ class SiteAliasFileDiscovery
             $path = $file->getRealPath();
             $result[] = $path;
         }
+        // Find every location where the parent directory name matches
+        // with the first part of the search pattern.
+        $match = explode('.', $this->locationFilter, 2)[0];
         // In theory we can use $finder->path() instead. That didn't work well,
         // in practice, though; had trouble correctly escaping the path separators.
         if (!empty($this->locationFilter)) {
-            $result = array_filter($result, function ($path) {
-                return SiteAliasName::locationFromPath($path) === $this->locationFilter;
+            $result = array_filter($result, function ($path) use ($match) {
+                return SiteAliasName::locationFromPath($path) === $match;
             });
         }
 

--- a/tests/SiteAliasManagerTest.php
+++ b/tests/SiteAliasManagerTest.php
@@ -148,6 +148,18 @@ root: /dup/path/to/single',
         sort($allNames);
 
         $this->assertEquals('@other.single.dev,@other.single.other', implode(',', $allNames));
+
+        $all = $this->manager->getMultiple('@dup.single');
+        $allNames = array_keys($all);
+        sort($allNames);
+
+        $this->assertEquals('@dup.single.alternate,@dup.single.dev', implode(',', $allNames));
+
+        $all = $this->manager->getMultiple('@other.single');
+        $allNames = array_keys($all);
+        sort($allNames);
+
+        $this->assertEquals('@other.single.dev,@other.single.other', implode(',', $allNames));
     }
 
     /**


### PR DESCRIPTION
### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no 
| Has tests?    | yes
| BC breaks?    | no     
| Deprecations? | no 

### Summary
Aliases such as @location.foo did not work with SiteAliasManager::getMultiple()