### PR TITLE
Only run root through realpath if it is present #8

### DIFF
--- a/src/AliasRecord.php
+++ b/src/AliasRecord.php
@@ -67,11 +67,16 @@ class AliasRecord extends Config implements AliasRecordInterface
 
     /**
      * @inheritdoc
+     *
+     * @throws \Exception when the alias does not specify a root.
      */
     public function root()
     {
+        if (!$this->hasRoot()) {
+            throw new \Exception('Site alias ' . $this->name . ' does not specify a root.');
+        }
         $root = $this->get('root');
-        if (!is_null($root) && $this->isLocal()) {
+        if ($this->isLocal()) {
             return FsUtils::realpath($root);
         }
         return $root;

--- a/tests/SiteAliasManagerTest.php
+++ b/tests/SiteAliasManagerTest.php
@@ -171,8 +171,10 @@ root: /dup/path/to/single',
         $this->assertEquals($alias->root(), '/path/to/single');
         /* @var AliasRecord $alias */
         $alias = $this->manager->get('@single.common');
-        // Ensure that when root is not specified in the alias, it returns null.
-        $this->assertNull($alias->root());
+        // Ensure that when root is not specified in the alias, an Exception is
+        // thrown.
+        $this->expectExceptionMessage('Site alias @single.common does not specify a root.');
+        $alias->root();
     }
 
     /**


### PR DESCRIPTION
### Overview
This pull request:

1. Adds a test to ensure that if root isn't present on an alias, it returns null.
2. Fixes AliasRecord::root() to return a null root on local environs.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| Has tests?    | yes
| BC breaks?    | no     
| Deprecations? | no 

