### PR TITLE
Fix local / remote checks.

### DIFF
--- a/src/AliasRecord.php
+++ b/src/AliasRecord.php
@@ -134,7 +134,7 @@ class AliasRecord extends Config implements AliasRecordInterface
      */
     public function isRemote()
     {
-        return !$this->isLocal();
+        return $this->has('host');
     }
 
     /**
@@ -142,10 +142,7 @@ class AliasRecord extends Config implements AliasRecordInterface
      */
     public function isLocal()
     {
-        if ($host = $this->remoteHost()) {
-            return $host == 'localhost' || $host == '127.0.0.1';
-        }
-        return true;
+        return !$this->isRemote();
     }
 
     /**


### PR DESCRIPTION

### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no 
| Has tests?    | maybe
| BC breaks?    | maybe (but if so, broken code buggy)     
| Deprecations? | no 

### Summary
We were using 'localhost' and '127.0.0.1' to indicate that the alias was for a 'local' system. However, these values are used when ssh'ing to docker containers, so we must treat them as 'remote'.
