### PR TITLE
Fixes #11: Prevent calls to 'localRoot' from failing when there is no…

### DIFF
--- a/src/AliasRecord.php
+++ b/src/AliasRecord.php
@@ -163,7 +163,7 @@ class AliasRecord extends Config implements AliasRecordInterface
      */
     public function localRoot()
     {
-        if ($this->isLocal()) {
+        if ($this->isLocal() && $this->hasRoot()) {
             return $this->root();
         }
 


### PR DESCRIPTION
… root set. The contract of this method, unlike root(), allows for the return of 'false' for 'no root'.

### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no 
| Has tests?    | no
| BC breaks?    | no     
| Deprecations? | no 

### Summary
See #11.