### PR TITLE
Allow empty aliases

### DIFF
--- a/src/SiteAliasFileLoader.php
+++ b/src/SiteAliasFileLoader.php
@@ -470,7 +470,7 @@ class SiteAliasFileLoader
         $data = $this->adjustIfSingleAlias($data);
         $env = $this->getEnvironmentName($aliasName, $data);
         $env_data = $this->getRequestedEnvData($data, $env);
-        if (!$env_data) {
+        if ($env_data === false) {
             return false;
         }
 


### PR DESCRIPTION
Since all alias properties are optional it should be possible to have empty site aliases.
Right now the following alias definition is not recognized.

```
# self.sites.yml
local: {}
```
```
$ drush @local st
 [preflight] The alias @local could not be found.
```
