### PR TITLE
Favor requested data over @self alias

### DIFF
--- a/src/SiteAliasFileLoader.php
+++ b/src/SiteAliasFileLoader.php
@@ -379,7 +379,7 @@ class SiteAliasFileLoader
             return false;
         }
         $selfSiteAliases = $this->findSelfSiteAliases($data, $path);
-        $data = array_merge($data, $selfSiteAliases);
+        $data = array_merge($selfSiteAliases, $data);
         return $data;
     }
 

--- a/tests/SiteAliasFileLoaderTest.php
+++ b/tests/SiteAliasFileLoaderTest.php
@@ -157,4 +157,16 @@ class SiteAliasFileLoaderTest extends TestCase
         $aliases = $this->sut->loadLocation('other');
         $this->assertEquals('@other.bob.dev,@other.bob.other,@other.fred.dev,@other.fred.other,@other.single.dev,@other.single.other', implode(',', array_keys($aliases)));
     }
+
+    public function testLoadOverrideSelf()
+    {
+        $this->sut->setRoot($this->fixturesDir() . '/sitealiases/self-override');
+        $this->sut->addSearchLocation($this->fixturesDir() . '/sitealiases/self-override/drush/sites');
+
+        // Specified site alias data should take precedence of @self data.
+        $name = new SiteAliasName('foo', 'prod');
+        $result = $this->sut->load($name);
+        $this->assertTrue($result instanceof SiteAlias);
+        $this->assertEquals('overridden', $result->get('bar'));
+    }
 }

--- a/tests/fixtures/sitealiases/self-override/drush/sites/foo.site.yml
+++ b/tests/fixtures/sitealiases/self-override/drush/sites/foo.site.yml
@@ -1,0 +1,2 @@
+prod:
+  bar: overridden

--- a/tests/fixtures/sitealiases/self-override/drush/sites/self.site.yml
+++ b/tests/fixtures/sitealiases/self-override/drush/sites/self.site.yml
@@ -1,0 +1,2 @@
+prod:
+  bar: baz


### PR DESCRIPTION
### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Has tests?    | yes
| BC breaks?    | no
| Deprecations? | no 

### Summary

When using `drush site:alias @my.alias`, it currently uses `@self.alias` (if it exists) instead of `@my.alias` since site-alias will use the same named environment in `@self` if it exists instead of the requested environment in `@my`. This also has implications for other commands that use site aliases as parameters, such as `sql:sync`. This PR ensures that the specified alias environment data takes precedence over any `@self` environment data with the same name.

### Description

Might be considered BC break if anyone is using the incorrect behavior.
Resolves drush-ops/drush#4424.