### PR TITLE
Fix PHP 8.1 compatibility

### DIFF
--- a/src/SiteAliasFileDiscovery.php
+++ b/src/SiteAliasFileDiscovery.php
@@ -26,7 +26,7 @@ class SiteAliasFileDiscovery
     protected $locationFilter;
     protected $depth;
 
-    public function __construct($searchLocations = [], $depth = '<= 1', $locationFilter = null)
+    public function __construct($searchLocations = [], $depth = '<= 1', $locationFilter = '')
     {
         $this->locationFilter = $locationFilter;
         $this->searchLocations = $searchLocations;


### PR DESCRIPTION
NULL may be passed to Consolidation\SiteAlias\SiteAliasFileDiscovery->splitLocationFromSite() and passing NULL to `explode()` is deprecated in PHP 8.1.
