### PR TITLE
replace null with empty string

### DIFF
--- a/src/SiteSpecParser.php
+++ b/src/SiteSpecParser.php
@@ -140,6 +140,10 @@ class SiteSpecParser
      */
     protected function match($spec)
     {
+        if($spec === null) {
+            $spec = '';
+        }
+
         foreach ($this->patterns() as $regex => $map) {
             if (preg_match($regex, $spec, $matches)) {
                 return $this->mapResult($map, $matches);


### PR DESCRIPTION
### Overview
Related to https://github.com/consolidation/site-alias/issues/48 -- fixes php 8.1 deprecation error.

Bug fix, no tests.

### Summary
Just transforms a null $spec to an empty string.
