### PR TITLE
feat: automatically create new release from tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+
+on:
+  push:
+    tags: ['**']
+
+name: Release
+
+permissions:
+  contents: write
+
+jobs:
+  create-release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Has tests?    | no
| BC breaks?    | no     
| Deprecations? | no 

### Summary

Adds a GH Actions workflow which automatically creates a release when a tag is pushed.

### Description

Fixes #62 
