### PR TITLE
Run roave with PHP 8.1.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install PHP with extensions
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 8.1
           coverage: none
           extensions: intl
 


### PR DESCRIPTION
Roave ^7 requires PHP 8+