### PR TITLE
PHP 8.4 compatibility

### DIFF
--- a/src/SiteAlias.php
+++ b/src/SiteAlias.php
@@ -23,7 +23,7 @@ class SiteAlias extends Config implements SiteAliasInterface
     /**
      * @inheritdoc
      */
-    public function __construct(array $data = null, $name = '', $env = '')
+    public function __construct(?array $data = null, $name = '', $env = '')
     {
         parent::__construct($data);
         if (!empty($env)) {

--- a/src/SiteAliasWithConfig.php
+++ b/src/SiteAliasWithConfig.php
@@ -36,7 +36,7 @@ class SiteAliasWithConfig implements SiteAliasInterface, ConfigRuntimeInterface
      * @return SiteAlias read-only site alias combined with the runtime
      *   config (overrides the site alias values) and the default config.
      */
-    public static function create(SiteAliasInterface $siteAlias, ConfigInterface $defaultConfig, ConfigInterface $runtimeConfig = null)
+    public static function create(SiteAliasInterface $siteAlias, ConfigInterface $defaultConfig, ?ConfigInterface $runtimeConfig = null)
     {
         $runtimeConfig = static::determineCorrectRuntimeConfig($defaultConfig, $runtimeConfig);
 


### PR DESCRIPTION
ref https://github.com/drush-ops/drush/issues/6069

### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no 
| Has tests?    | no
| BC breaks?    | no     
| Deprecations? | yes

### Summary
Fixed all nullable type declarations found

###Description

Testing with official docker image `docker run --rm -v $(pwd):/mnt -w /mnt php:8.4.0alpha2-cli-alpine find src -type f -name '*.php' -exec php -l {} \;`
