### PR TITLE
Allow Symfony 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,13 +25,13 @@
     "require": {
         "php": ">=7.4",
         "consolidation/config": "^1.2.1 || ^2 || ^3",
-        "symfony/filesystem": "^5.4 || ^6 || ^7",
-        "symfony/finder": "^5 || ^6 || ^7"
+        "symfony/filesystem": "^5.4 || ^6 || ^7 || ^8",
+        "symfony/finder": "^5 || ^6 || ^7 || ^8"
     },
     "require-dev": {
         "php-coveralls/php-coveralls": "^2.4.2",
         "squizlabs/php_codesniffer": "^3",
-        "symfony/var-dumper": "^4",
+        "symfony/var-dumper": "^4 || ^5 || ^6 || ^7 || ^8",
         "phpunit/phpunit": ">=7",
         "yoast/phpunit-polyfills": "^0.2.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8c367fdbef3a51cd922f58527336ccab",
+    "content-hash": "1de65e394cbe12f08c026999d9e1c4e2",
     "packages": [
         {
             "name": "consolidation/config",
@@ -4225,15 +4225,15 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.4"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.2.17"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
Widen symfony/* constraints to allow ^8.

No code changes needed — verified that the APIs used by this package are unchanged in Symfony 8.

Ref: https://github.com/drush-ops/drush/issues/6536